### PR TITLE
Fix for missing message issue

### DIFF
--- a/PoshBot/Implementations/Slack/SlackBackend.ps1
+++ b/PoshBot/Implementations/Slack/SlackBackend.ps1
@@ -188,17 +188,17 @@ class SlackBackend : Backend {
         $messages = New-Object -TypeName System.Collections.ArrayList
         try {
             # Read the output stream from the receive job and get any messages since our last read
-            $jsonResult = $this.Connection.ReadReceiveJob()
+            [string[]]$jsonResults = $this.Connection.ReadReceiveJob()
 
-            if ($null -ne $jsonResult -and $jsonResult -ne [string]::Empty) {
-                #Write-Debug -Message "[SlackBackend:ReceiveMessage] Received `n$jsonResult"
-                $this.LogDebug('Received message', $jsonResult)
+            foreach ($jsonResult in $jsonResults) {
+                if ($null -ne $jsonResult -and $jsonResult -ne [string]::Empty) {
+                    #Write-Debug -Message "[SlackBackend:ReceiveMessage] Received `n$jsonResult"
+                    $this.LogDebug('Received message', $jsonResult)
 
-                # Strip out Slack's URI formatting
-                $jsonResult = $this._SanitizeURIs($jsonResult)
+                    # Strip out Slack's URI formatting
+                    $jsonResult = $this._SanitizeURIs($jsonResult)
 
-                $slackMessages = @($jsonResult | ConvertFrom-Json)
-                foreach ($slackMessage in $slackMessages) {
+                    $slackMessage = @($jsonResult | ConvertFrom-Json)
 
                     # Slack will sometimes send back ephemeral messages from user [SlackBot]. Ignore these
                     # These are messages like notifing that a message won't be unfurled because it's already
@@ -341,6 +341,7 @@ class SlackBackend : Backend {
                     } else {
                         $this.LogDebug("Message type is [$($slackMessage.Type)]. Ignoring")
                     }
+                    
                 }
             }
         } catch {

--- a/PoshBot/Implementations/Slack/SlackConnection.ps1
+++ b/PoshBot/Implementations/Slack/SlackConnection.ps1
@@ -100,7 +100,7 @@ class SlackConnection : Connection {
     }
 
     # Read all available data from the job
-    [string]ReadReceiveJob() {
+    [string[]]ReadReceiveJob() {
         # Read stream info from the job so we can log them
         $infoStream = $this.ReceiveJob.ChildJobs[0].Information.ReadAll()
         $warningStream = $this.ReceiveJob.ChildJobs[0].Warning.ReadAll()
@@ -131,7 +131,8 @@ class SlackConnection : Connection {
         }
 
         if ($this.ReceiveJob.HasMoreData) {
-            return $this.ReceiveJob.ChildJobs[0].Output.ReadAll()
+            [string[]]$jobResult = $this.ReceiveJob.ChildJobs[0].Output.ReadAll()
+            return $jobResult
         } else {
             return $null
         }


### PR DESCRIPTION
Changed Slack Backend ReadReceivJob type from [string] to [string[]] to handle multiple message properly
Changed Slack Backend ReceiveMessage() to handle a [string[]]  as input of slack message processing

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
